### PR TITLE
feat: PR連携機能(--from-pr)の試行 #8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # 実装ログ（ローカル作業記録）
 _docs/templates/
+
+# Worktree用ローカルコンテキスト
+CLAUDE.local.md


### PR DESCRIPTION
## Summary
- GitHub PRとClaude Codeセッションの連携機能を試行・検証するためのPR
- `--from-pr` フラグ、セッション自動リンク、PRレビューステータスインジケーターの動作確認
- worktree用 `CLAUDE.local.md` を `.gitignore` に追加

## 試行対象機能
- [x] `claude --from-pr <PR番号>` でPR連携セッションを起動
- [x] PRのURLを指定して `--from-pr` を試す
- [x] `gh pr create` でPR作成時のセッション自動リンクを確認
- [x] プロンプトフッターのPRレビューステータスインジケーターを確認

Closes #8