### PR TITLE
試行: Issue #9 「ここから要約」機能の検証

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # 実装ログ（ローカル作業記録）
 _docs/templates/
+
+# Worktree用ローカルコンテキスト
+CLAUDE.local.md


### PR DESCRIPTION
## Summary
- v2.1.32で追加された「ここから要約（Summarize from here）」機能の試行・検証
- worktree用ローカルコンテキストファイル（CLAUDE.local.md）を.gitignoreに追加

## 試行結果
- リワインドメニュー（Esc×2）の「メッセージセレクター」に「Summarize from here」オプションが表示されることを確認
- `/compact`（全体要約）とは異なり、選択した地点以降のみを部分的に要約できる機能

## 所見
- 公式Changelogの記載: "Added 'Summarize from here' to the message selector, allowing partial conversation summarization"
- コンテキストウィンドウの効率的な管理に有用（初期の設計議論を保持しつつ、冗長な部分のみ圧縮可能）

Closes #9