### PR TITLE
feat: spinnerVerbsカスタマイズ設定を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,10 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "spinnerVerbs": {
+    "mode": "replace",
+    "verbs": ["Thinking"]
   }
 }

--- a/trial-report.md
+++ b/trial-report.md
@@ -1,41 +1,64 @@
-# Agent Teams 試行レポート
+# Trial Report: Worktree統合機能 (Issue #2)
 
-## 基本情報
+## 試行バージョン
 
-- **試行日**: 2026-02-22
-- **Claude Code バージョン**: v2.1.50
-- **ターミナル**: Ghostty
-- **表示モード**: in-process
-- **試行シナリオ**: NARUTO 豆知識のチーム調査
+- Claude Code: v2.1.50
+- 試行日: 2026-02-21
 
-## 試行結果チェックリスト
+## 試行した機能
 
-### チーム管理
-- [ ] チーム作成 & チームメンバーのスポーン
-- [ ] Shift+Up/Down でチームメンバー切替
-- [ ] Ctrl+T でタスクリスト表示
-- [ ] チームメンバーのシャットダウン
-- [ ] チームのクリーンアップ
+### 1. `--worktree` / `-w` CLIフラグ
 
-### メッセージング
-- [ ] リーダーからチームメンバーへの直接メッセージ
-- [ ] チームメンバーからリーダーへの報告
-- [ ] チームメンバー間のメッセージ送受信
+**概要**: Claude Code 起動時に隔離された git worktree を自動作成する機能。
 
-### 成果物
-- [ ] `naruto-trivia/character-story.md` にチームメンバーが内容を記入
-- [ ] `naruto-trivia/production-data.md` にチームメンバーが内容を記入
+**確認結果**:
+- `claude --help` にて `-w, --worktree [name]` フラグを確認
+- `--tmux` フラグとの併用が可能（iTerm2ではnative pane、それ以外はtmux）
+- ネストしたClaude Codeセッションの起動は安全上の理由で制限されている
 
-## 観察メモ
+### 2. `EnterWorktree` ツール
 
-### 動作の所感
-<!-- 試行中の観察メモをここに記載 -->
+**概要**: セッション中にプログラム的に新しい worktree へ切り替える機能。
 
-### 問題点・注意点
-<!-- 発見した問題や注意点をここに記載 -->
+**確認結果**:
+- worktree 内からでも新しい worktree を作成可能（ネスト制約なし）
+- 新しい worktree はメインリポジトリの `.claude/worktrees/<name>` に作成される
+- ブランチ名は `worktree-<name>` 形式で自動生成
+- CWD が自動的に新しい worktree に切り替わる
+- セッション終了時、変更がなければ自動クリーンアップ
 
-### subagents との体感の違い
-<!-- Agent Teams と subagents の違いを体感ベースで記載 -->
+### 3. サブエージェント `isolation: "worktree"`
 
-## 結論
-<!-- 試行の全体的な評価と結論をここに記載 -->
+**概要**: Task ツールで `isolation: "worktree"` を指定し、サブエージェントを隔離環境で実行する機能。
+
+**確認結果**:
+- サブエージェントごとに `agent-<hash>` 形式の一意な worktree が自動生成
+- 専用ブランチ `worktree-agent-<hash>` で完全に隔離
+- サブエージェントが作成したファイルは他の worktree に一切影響しない
+- 変更があった場合は worktree が保持され、パスとブランチ名が返却される
+- 変更がなければ自動クリーンアップ
+- 2段ネスト（worktree > サブエージェント worktree）も動作確認済み
+
+### 4. メイン working tree への影響確認
+
+**確認結果**:
+- サブエージェントが `isolation-test.txt` を作成
+- メインリポジトリ、issue-2 worktree、EnterWorktree で作成した worktree のいずれにもファイルは存在しない
+- サブエージェントの worktree 内にのみファイルが存在することを確認
+- 各 worktree の `git status` にも影響なし
+
+## 総合評価
+
+**すべての試行項目が正常に動作。**
+
+Worktree統合機能は、以下のユースケースで特に有用:
+
+1. **並行開発**: 複数の issue を別々の worktree で同時作業
+2. **安全なサブエージェント実行**: `isolation: "worktree"` により、サブエージェントの変更が本番コードに影響しない
+3. **実験的変更**: EnterWorktree でいつでも隔離環境を作成し、気に入らなければ破棄
+
+## 注意点
+
+- ネストした Claude Code セッション（`claude` コマンドの入れ子）は安全上の理由で制限される
+- worktree は同じ `.git` データベースを共有するため、ブランチの重複チェックアウトはできない
+- `--tmux` は `--worktree` との併用が前提


### PR DESCRIPTION
## Summary
- spinnerVerbs を `mode: "replace"` で `"Thinking"` 1語に固定する設定を追加
- デフォルトの56語ランダム動詞（Clauding, Honking, Noodling等）を排除し、常に「Thinking...」のみ表示されるようにした
- ユーザースコープ（`~/.claude/settings.json`）にも同様の設定を適用済み

## 試行結果
- `spinnerVerbs`: 日本語動詞10語（考え中, 錬成中, 詠唱中等）での動作を確認後、最終的に「Thinking」1語に固定
- `spinnerTipsOverride`: カスタムtips設定を試行後、デフォルトtipsのままで十分と判断し削除
- 設定はセッション再起動時に反映されることを確認

## 学んだこと
- `spinnerVerbs`: v2.1.23 導入。`mode: "append"`（追加）/ `"replace"`（置換）を選択可能
- `spinnerTipsOverride`: v2.1.45 導入。`excludeDefault` で組み込みtipsとの共存/排他を制御
- 配列に複数指定するとランダムで選ばれる。1語だけ指定すれば固定表示になる
- 設定優先順位: プロジェクトスコープ > ユーザースコープ

Closes #12