### PR TITLE
docs(sandbox): add JSDoc comments to all exported functions

### DIFF
--- a/sandbox/report.ts
+++ b/sandbox/report.ts
@@ -1,0 +1,117 @@
+// Sandbox report generator for testing /simplify and /batch commands
+
+import { formatDate, formatDateTime, formatTime } from "./utils";
+
+type ReportFormat = "csv" | "tsv" | "text";
+
+interface ReportConfig {
+  title: string;
+  includeDate: boolean;
+  includeTime: boolean;
+  format: ReportFormat;
+}
+
+const FORMAT_DELIMITERS: Record<ReportFormat, string> = {
+  csv: ",",
+  tsv: "\t",
+  text: " | ",
+};
+
+function formatItem(item: Record<string, unknown>, format: ReportFormat): string {
+  const keys = Object.keys(item);
+  if (format === "text") {
+    return keys.map((k) => `${k}: ${item[k]}`).join(FORMAT_DELIMITERS.text);
+  }
+  return keys.map((k) => String(item[k])).join(FORMAT_DELIMITERS[format]);
+}
+
+/**
+ * 設定に基づいてレポートを生成する
+ * @param data - レポートに含めるデータの配列
+ * @param config - レポートのタイトル、日時表示、フォーマットを指定する設定
+ * @returns フォーマットされたレポート文字列
+ */
+export function generateReport(
+  data: Record<string, unknown>[],
+  config: ReportConfig,
+): string {
+  const { title, includeDate, includeTime, format } = config;
+  const lines: string[] = [];
+  const now = new Date();
+
+  lines.push(`=== ${title} ===`);
+
+  if (includeDate && includeTime) {
+    lines.push(`Generated: ${formatDateTime(now)}`);
+  } else if (includeDate) {
+    lines.push(`Generated: ${formatDate(now)}`);
+  } else if (includeTime) {
+    lines.push(`Generated: ${formatTime(now)}`);
+  }
+
+  lines.push("");
+
+  for (const item of data) {
+    lines.push(formatItem(item, format));
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * CSV形式のレポートを生成する
+ * @param data - レポートに含めるデータの配列
+ * @param title - レポートのタイトル
+ * @param includeDate - 生成日付を含めるかどうか
+ * @param includeTime - 生成時刻を含めるかどうか
+ * @returns CSV形式のレポート文字列
+ */
+export function generateCsvReport(
+  data: Record<string, unknown>[],
+  title: string,
+  includeDate: boolean,
+  includeTime: boolean,
+): string {
+  return generateReport(data, { title, includeDate, includeTime, format: "csv" });
+}
+
+/**
+ * TSV形式のレポートを生成する
+ * @param data - レポートに含めるデータの配列
+ * @param title - レポートのタイトル
+ * @param includeDate - 生成日付を含めるかどうか
+ * @param includeTime - 生成時刻を含めるかどうか
+ * @returns TSV形式のレポート文字列
+ */
+export function generateTsvReport(
+  data: Record<string, unknown>[],
+  title: string,
+  includeDate: boolean,
+  includeTime: boolean,
+): string {
+  return generateReport(data, { title, includeDate, includeTime, format: "tsv" });
+}
+
+/**
+ * レポート文字列の行数をカウントする
+ * @param report - 行数をカウントするレポート文字列
+ * @returns レポートの行数
+ */
+export function countReportLines(report: string): number {
+  return report.split("\n").length;
+}
+
+/**
+ * 指定されたキーと値でレポートデータをフィルタリングする
+ * @param data - フィルタリング対象のデータ配列
+ * @param key - フィルタリングに使用するキー名
+ * @param value - フィルタリングに使用する値
+ * @returns フィルタ条件に一致するデータの配列
+ */
+export function filterReportData(
+  data: Record<string, unknown>[],
+  key: string,
+  value: unknown,
+): Record<string, unknown>[] {
+  return data.filter((item) => item[key] === value);
+}

--- a/sandbox/user-service.ts
+++ b/sandbox/user-service.ts
@@ -1,0 +1,147 @@
+// Sandbox user service for testing /simplify and /batch commands
+
+import { formatDate, formatDateTime } from "./utils";
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const users: User[] = [];
+
+/**
+ * 新しいユーザーを作成してストアに追加する
+ * @param name - ユーザーの名前
+ * @param email - ユーザーのメールアドレス
+ * @returns 作成されたUserオブジェクト
+ */
+export function addUser(name: string, email: string): User {
+  const now = new Date();
+  const user: User = {
+    id: Math.random().toString(36).substring(2, 15),
+    name,
+    email,
+    createdAt: now,
+    updatedAt: now,
+  };
+  users.push(user);
+  return user;
+}
+
+/**
+ * メールアドレスでユーザーを検索する
+ * @param email - 検索するメールアドレス
+ * @returns 見つかったUserオブジェクト、存在しない場合はundefined
+ */
+export function findUserByEmail(email: string): User | undefined {
+  return users.find((u) => u.email === email);
+}
+
+/**
+ * IDでユーザーを検索する
+ * @param id - 検索するユーザーID
+ * @returns 見つかったUserオブジェクト、存在しない場合はundefined
+ */
+export function findUserById(id: string): User | undefined {
+  return users.find((u) => u.id === id);
+}
+
+/**
+ * 全ユーザーのメールアドレス一覧を取得する
+ * @returns メールアドレスの配列
+ */
+export function getAllUserEmails(): string[] {
+  return users.map((u) => u.email);
+}
+
+/**
+ * 全ユーザーのサマリー文字列一覧を取得する
+ * @returns ユーザー名、メール、作成日、更新日時を含むサマリー文字列の配列
+ */
+export function getUserSummaries(): string[] {
+  return users.map((user) => {
+    const createdDate = formatDate(user.createdAt);
+    const updatedDate = formatDateTime(user.updatedAt);
+    return `${user.name} (${user.email}) - created: ${createdDate}, updated: ${updatedDate}`;
+  });
+}
+
+function updateUserField(
+  id: string,
+  updater: (user: User) => void,
+): boolean {
+  const user = findUserById(id);
+  if (!user) return false;
+  updater(user);
+  user.updatedAt = new Date();
+  return true;
+}
+
+/**
+ * ユーザーの名前を更新する
+ * @param id - 更新対象のユーザーID
+ * @param newName - 新しい名前
+ * @returns 更新に成功した場合はtrue、ユーザーが見つからない場合はfalse
+ */
+export function updateUserName(id: string, newName: string): boolean {
+  return updateUserField(id, (user) => { user.name = newName; });
+}
+
+/**
+ * ユーザーのメールアドレスを更新する
+ * @param id - 更新対象のユーザーID
+ * @param newEmail - 新しいメールアドレス
+ * @returns 更新に成功した場合はtrue、ユーザーが見つからない場合はfalse
+ */
+export function updateUserEmail(id: string, newEmail: string): boolean {
+  return updateUserField(id, (user) => { user.email = newEmail; });
+}
+
+/**
+ * ユーザーをストアから削除する
+ * @param id - 削除対象のユーザーID
+ * @returns 削除に成功した場合はtrue、ユーザーが見つからない場合はfalse
+ */
+export function deleteUser(id: string): boolean {
+  const index = users.findIndex((u) => u.id === id);
+  if (index === -1) return false;
+  users.splice(index, 1);
+  return true;
+}
+
+/**
+ * 名前またはメールアドレスでユーザーを検索する（大文字小文字を区別しない）
+ * @param query - 検索クエリ文字列
+ * @returns 検索条件に一致するUserオブジェクトの配列
+ */
+export function searchUsers(query: string): User[] {
+  const lowerQuery = query.toLowerCase();
+  return users.filter(
+    (user) =>
+      user.name.toLowerCase().includes(lowerQuery) ||
+      user.email.toLowerCase().includes(lowerQuery),
+  );
+}
+
+/**
+ * APIからユーザー情報を取得し、ストアに保存する（既存ユーザーがいればそちらを返す）
+ * @param apiUrl - ユーザー情報を取得するAPIのURL
+ * @returns 取得または既存のUserオブジェクト
+ */
+export async function fetchAndStoreUser(apiUrl: string): Promise<User> {
+  const response = await fetch(apiUrl);
+  const data = await response.json();
+  return findUserByEmail(data.email) ?? addUser(data.name, data.email);
+}
+
+/**
+ * 複数のAPIから並行してユーザー情報を取得し、ストアに保存する
+ * @param urls - ユーザー情報を取得するAPIのURL配列
+ * @returns 取得されたUserオブジェクトの配列
+ */
+export async function fetchMultipleUsers(urls: string[]): Promise<User[]> {
+  return Promise.all(urls.map((url) => fetchAndStoreUser(url)));
+}

--- a/sandbox/utils.ts
+++ b/sandbox/utils.ts
@@ -1,0 +1,34 @@
+// Sandbox utilities for testing /simplify and /batch commands
+
+/**
+ * 日付をYYYY-MM-DD形式の文字列にフォーマットする
+ * @param date - フォーマット対象のDateオブジェクト
+ * @returns YYYY-MM-DD形式の日付文字列
+ */
+export function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * 時刻をHH:MM:SS形式の文字列にフォーマットする
+ * @param date - フォーマット対象のDateオブジェクト
+ * @returns HH:MM:SS形式の時刻文字列
+ */
+export function formatTime(date: Date): string {
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+/**
+ * 日時をYYYY-MM-DD HH:MM:SS形式の文字列にフォーマットする
+ * @param date - フォーマット対象のDateオブジェクト
+ * @returns YYYY-MM-DD HH:MM:SS形式の日時文字列
+ */
+export function formatDateTime(date: Date): string {
+  return `${formatDate(date)} ${formatTime(date)}`;
+}


### PR DESCRIPTION
## Summary

- sandbox/内の3ファイル（utils.ts, report.ts, user-service.ts）の全19個のexported関数にJSDocコメントを追加
- 内部関数（formatItem, updateUserField）はスキップ
- `/simplify` によるコードレビュー済み（1件の不正確なJSDoc記述を修正）

## Test plan

- [x] `npx tsx --eval "import('./sandbox/utils.ts')"` で構文チェック通過
- [x] `npx tsx --eval "import('./sandbox/report.ts')"` で構文チェック通過
- [x] `npx tsx --eval "import('./sandbox/user-service.ts')"` で構文チェック通過
- [x] `/simplify` による3エージェント並行レビュー完了

Closes #73