### PR TITLE
feat: フックの agent_id / agent_type フィールド動作検証 (#101)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/camone/dev/claude-code/claude-code-learn/cc-changelog-ja/_cc-new-feature-try-worktrees/issue-101-hook-agent-id-type/hook-agent-dump.sh",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/hook-agent-dump.sh
+++ b/hook-agent-dump.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Issue #101: agent_id / agent_type フィールド調査用フック
+# stdin の JSON をダンプして、agent_id / agent_type の存在を確認する
+
+LOGFILE="/tmp/agent-hook-log.txt"
+
+# stdin から JSON を読み取り
+INPUT=$(cat)
+
+# タイムスタンプ付きでログに記録
+echo "=== $(date '+%Y-%m-%d %H:%M:%S') ===" >> "$LOGFILE"
+echo "$INPUT" | python3 -m json.tool >> "$LOGFILE" 2>/dev/null || echo "$INPUT" >> "$LOGFILE"
+echo "" >> "$LOGFILE"
+
+# agent_id / agent_type をハイライト抽出
+AGENT_ID=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('agent_id','NOT_FOUND'))" 2>/dev/null)
+AGENT_TYPE=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('agent_type','NOT_FOUND'))" 2>/dev/null)
+
+echo "--- agent fields ---" >> "$LOGFILE"
+echo "agent_id: $AGENT_ID" >> "$LOGFILE"
+echo "agent_type: $AGENT_TYPE" >> "$LOGFILE"
+echo "===================" >> "$LOGFILE"
+echo "" >> "$LOGFILE"


### PR DESCRIPTION
## Summary
フックイベント(v2.1.69)で追加された `agent_id` / `agent_type` フィールドの動作検証。PostToolUse フックで stdin JSON をダンプし、メインエージェント・サブエージェント・`claude --agent` の3パターンでフィールドの有無と値を確認した。

## Changes
- `hook-agent-dump.sh`: stdin JSON から agent_id / agent_type を抽出しログ出力するフックスクリプト
- `.claude/settings.json`: PostToolUse フックに agent_id / agent_type ダンプスクリプトを登録（既存の InstructionsLoaded フック設定と統合）

## Test Plan
- [x] メインエージェントのツール使用時にフック発火を確認（agent_id / agent_type はフィールドなし）
- [x] サブエージェント(Explore)のツール使用時に agent_id と agent_type が記録されることを確認
- [x] `claude --agent article-summarizer` 実行時に agent_type にエージェント名が設定されることを確認

## Breaking Changes
なし

## Related Issues
Closes #101