### PR TITLE
chore: worktree コンフリクト防止ルールを追加

### DIFF
--- a/.claude/rules/worktree-conflict-prevention.md
+++ b/.claude/rules/worktree-conflict-prevention.md
@@ -1,0 +1,18 @@
+# Worktree コンフリクト防止ルール
+
+## 共有ファイル変更前の必須手順
+
+`.gitignore`、`package.json`、`tsconfig.json` 等の共有設定ファイルを変更する前に、必ず以下を実行すること:
+
+1. `git fetch origin main` で最新の main を取得
+2. `git show origin/main:<ファイル名>` で main 側の現在の内容を確認
+3. 追加しようとしているエントリが既に main に存在する場合は、変更しない
+4. 変更が必要な場合は、先に `git merge origin/main` を実行してから変更する
+
+## PR作成前の必須手順
+
+PR を作成する前に、必ず以下を実行すること:
+
+1. `git fetch origin main`
+2. `git merge origin/main` でコンフリクトがないことを確認
+3. コンフリクトがある場合は解消してからPRを作成する


### PR DESCRIPTION
## Summary

- `.claude/rules/worktree-conflict-prevention.md` を追加
- 共有ファイル（`.gitignore`等）の変更前に `origin/main` の確認を必須化
- PR作成前にマージコンフリクトがないことの確認を必須化

## 背景

worktree 運用で `.gitignore` のコンフリクトが頻発していた。
原因はブランチが古い main から分岐しており、main 側に後から追加されたエントリと衝突するため。

`.claude/rules/` に配置することで、全 worktree セッションで Claude Code が自動的にこのルールを読み込み、コンフリクトを未然に防止する。

## Test plan

- [x] `.claude/rules/` にルールファイルが配置されていることを確認
- [ ] 新しい worktree セッションでルールが読み込まれることを確認